### PR TITLE
[FLINK-19680] Explicitly set alignment timeout to 0 in the existing Unaligned Checkpoints benchmarks

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
@@ -88,6 +88,7 @@ public class UnalignedCheckpointTimeBenchmark extends BenchmarkBase {
             env.setParallelism(parallelism);
             env.enableCheckpointing(CHECKPOINT_INTERVAL_MS);
             env.getCheckpointConfig().enableUnalignedCheckpoints(true);
+            env.getCheckpointConfig().setAlignmentTimeout(0);
         }
 
         protected Configuration createConfiguration() {


### PR DESCRIPTION
This should fix the current benchmark time outing and will make the benchmark independent of any potential future default value changes.