### PR TITLE
[FLINK-20612][runtime] Add benchmarks for scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.12-SNAPSHOT</flink.version>
+		<flink.version>1.13-SNAPSHOT</flink.version>
 		<flink.shaded.version>10.0</flink.shaded.version>
 		<netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ under the License.
 		<thrift.version>0.13.0</thrift.version>
 		<protobuf.version>3.11.4</protobuf.version>
 		<netty-tcnative.flavor>dynamic</netty-tcnative.flavor>
-		<benchmarkExcludes>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*</benchmarkExcludes>
+		<benchmarkExcludes>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*,org.apache.flink.scheduler.benchmark.*</benchmarkExcludes>
 		<benchmarks>.*</benchmarks>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@ under the License.
 			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 			<type>test-jar</type>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/apache/flink/scheduler/benchmark/JobConfiguration.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/JobConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark;
+
+import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+
+/**
+ * {@link JobConfiguration} contains the configuration of a STREAMING/BATCH job.
+ * It concludes {@link DistributionPattern}, {@link ResultPartitionType}, {@link ScheduleMode}, {@link ExecutionMode}.
+ */
+public enum JobConfiguration {
+
+	STREAMING(DistributionPattern.ALL_TO_ALL,
+			  ResultPartitionType.PIPELINED,
+			  ScheduleMode.EAGER,
+			  ExecutionMode.PIPELINED),
+
+	BATCH(DistributionPattern.ALL_TO_ALL,
+		  ResultPartitionType.BLOCKING,
+		  ScheduleMode.LAZY_FROM_SOURCES,
+		  ExecutionMode.BATCH);
+
+	private final static int PARALLELISM = 4000;
+	private final DistributionPattern distributionPattern;
+	private final ResultPartitionType resultPartitionType;
+	private final ScheduleMode scheduleMode;
+	private final ExecutionMode executionMode;
+
+	JobConfiguration(
+			DistributionPattern distributionPattern,
+			ResultPartitionType resultPartitionType,
+			ScheduleMode scheduleMode,
+			ExecutionMode executionMode) {
+		this.distributionPattern = distributionPattern;
+		this.resultPartitionType = resultPartitionType;
+		this.scheduleMode = scheduleMode;
+		this.executionMode = executionMode;
+	}
+
+	public int getParallelism() {
+		return PARALLELISM;
+	}
+
+	public DistributionPattern getDistributionPattern() {
+		return distributionPattern;
+	}
+
+	public ResultPartitionType getResultPartitionType() {
+		return resultPartitionType;
+	}
+
+	public ScheduleMode getScheduleMode() {
+		return scheduleMode;
+	}
+
+	public ExecutionMode getExecutionMode() {
+		return executionMode;
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkBase.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark;
+
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The base class of all benchmarks related to the scheduler.
+ */
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 6, jvmArgsAppend = {
+		"-Djava.rmi.server.hostname=127.0.0.1",
+		"-Dcom.sun.management.jmxremote.authenticate=false",
+		"-Dcom.sun.management.jmxremote.ssl=false",
+		"-Dcom.sun.management.jmxremote.ssl"
+})
+public class SchedulerBenchmarkBase {
+
+	public static void runBenchmark(Class<?> clazz) throws RunnerException {
+		Options options = new OptionsBuilder()
+				.verbosity(VerboseMode.NORMAL)
+				.include(".*" + clazz.getCanonicalName() + ".*")
+				.build();
+
+		new Runner(options).run();
+	}
+
+	@TearDown
+	public void teardown() {
+		TestingUtils.defaultExecutor().shutdownNow();
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utilities for scheduler benchmarks.
+ */
+public class SchedulerBenchmarkUtils {
+
+	public static List<JobVertex> createDefaultJobVertices(JobConfiguration jobConfiguration) {
+
+		final List<JobVertex> jobVertices = new ArrayList<>();
+
+		final JobVertex source = new JobVertex("source");
+		source.setInvokableClass(NoOpInvokable.class);
+		source.setParallelism(jobConfiguration.getParallelism());
+		jobVertices.add(source);
+
+		final JobVertex sink = new JobVertex("sink");
+		sink.setInvokableClass(NoOpInvokable.class);
+		sink.setParallelism(jobConfiguration.getParallelism());
+		jobVertices.add(sink);
+
+		sink.connectNewDataSetAsInput(
+				source,
+				jobConfiguration.getDistributionPattern(),
+				jobConfiguration.getResultPartitionType());
+
+		return jobVertices;
+	}
+
+	public static JobGraph createJobGraph(JobConfiguration jobConfiguration) throws IOException {
+		return createJobGraph(Collections.emptyList(), jobConfiguration);
+	}
+
+	public static JobGraph createJobGraph(
+			List<JobVertex> jobVertices,
+			JobConfiguration jobConfiguration) throws IOException {
+
+		final JobGraph jobGraph = new JobGraph(jobVertices.toArray(new JobVertex[0]));
+
+		jobGraph.setScheduleMode(jobConfiguration.getScheduleMode());
+
+		final ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setExecutionMode(jobConfiguration.getExecutionMode());
+		jobGraph.setExecutionConfig(executionConfig);
+
+		return jobGraph;
+	}
+
+	public static ExecutionGraph createAndInitExecutionGraph(
+			List<JobVertex> jobVertices,
+			JobConfiguration jobConfiguration) throws Exception {
+
+		final JobGraph jobGraph = createJobGraph(
+				jobVertices,
+				jobConfiguration);
+
+		final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+		final DefaultScheduler scheduler = SchedulerTestingUtils.createScheduler(jobGraph, mainThreadExecutor);
+
+		return scheduler.getExecutionGraph();
+	}
+
+	public static void deployTasks(
+			ExecutionGraph executionGraph,
+			JobVertexID jobVertexID,
+			TestingLogicalSlotBuilder slotBuilder,
+			boolean sendScheduleOrUpdateConsumersMessage) throws JobException, ExecutionException, InterruptedException {
+
+		for (ExecutionVertex vertex : executionGraph.getJobVertex(jobVertexID).getTaskVertices()) {
+			LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+			Execution execution = vertex.getCurrentExecutionAttempt();
+			execution.registerProducedPartitions(
+					slot.getTaskManagerLocation(),
+					sendScheduleOrUpdateConsumersMessage).get();
+			assignResourceAndDeploy(vertex, slot);
+		}
+	}
+
+	public static void deployAllTasks(
+			ExecutionGraph executionGraph,
+			TestingLogicalSlotBuilder slotBuilder) throws JobException, ExecutionException, InterruptedException {
+
+		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+			LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+			vertex.getCurrentExecutionAttempt().registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
+			assignResourceAndDeploy(vertex, slot);
+		}
+	}
+
+	private static void assignResourceAndDeploy(ExecutionVertex vertex, LogicalSlot slot) throws JobException {
+		vertex.tryAssignResource(slot);
+		vertex.deploy();
+	}
+
+	public static void transitionTaskStatus(
+			ExecutionGraph executionGraph,
+			JobVertexID jobVertexID,
+			ExecutionState state) {
+
+		for (ExecutionVertex vertex : executionGraph
+				.getJobVertex(jobVertexID)
+				.getTaskVertices()) {
+			executionGraph.updateState(
+					new TaskExecutionStateTransition(
+							new TaskExecutionState(
+									executionGraph.getJobID(),
+									vertex.getCurrentExecutionAttempt().getAttemptId(),
+									state)));
+		}
+	}
+
+	public static void transitionTaskStatus(
+			DefaultScheduler scheduler,
+			AccessExecutionJobVertex vertex,
+			int subtask,
+			ExecutionState executionState) {
+
+		final ExecutionAttemptID attemptId = vertex.getTaskVertices()[subtask]
+				.getCurrentExecutionAttempt()
+				.getAttemptId();
+		scheduler.updateTaskExecutionState(
+				new TaskExecutionState(
+						scheduler.getExecutionGraph().getJobID(),
+						attemptId,
+						executionState));
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+/**
+ * The benchmark of deploying downstream tasks in a BATCH job.
+ * The related method is {@link Execution#deploy}.
+ */
+public class DeployingDownstreamTasksInBatchJobBenchmark extends DeployingTasksBenchmarkBase {
+
+	@Param("BATCH")
+	private JobConfiguration jobConfiguration;
+
+	private ExecutionVertex[] vertices;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(DeployingDownstreamTasksInBatchJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		createAndSetupExecutionGraph(jobConfiguration);
+
+		final JobVertex source = jobVertices.get(0);
+
+		for (ExecutionVertex ev : executionGraph.getJobVertex(source.getID()).getTaskVertices()) {
+			Execution execution = ev.getCurrentExecutionAttempt();
+			execution.deploy();
+		}
+
+		final JobVertex sink = jobVertices.get(1);
+
+		vertices = executionGraph.getJobVertex(sink.getID()).getTaskVertices();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void deployDownstreamTasks() throws Exception {
+		for (ExecutionVertex ev : vertices) {
+			Execution execution = ev.getCurrentExecutionAttempt();
+			execution.deploy();
+		}
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/**
+ * The base class of benchmarks related to deploying tasks.
+ */
+public class DeployingTasksBenchmarkBase extends SchedulerBenchmarkBase {
+
+	List<JobVertex> jobVertices;
+	ExecutionGraph executionGraph;
+	BlockingQueue<TaskDeploymentDescriptor> taskDeploymentDescriptors;
+
+	public void createAndSetupExecutionGraph(JobConfiguration jobConfiguration) throws Exception {
+
+		jobVertices = createDefaultJobVertices(jobConfiguration);
+
+		executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+
+		taskDeploymentDescriptors = new ArrayBlockingQueue<>(jobConfiguration.getParallelism() * 2);
+
+		final SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
+		taskManagerGateway.setSubmitConsumer(taskDeploymentDescriptors::offer);
+
+		final TestingLogicalSlotBuilder slotBuilder =
+				new TestingLogicalSlotBuilder().setTaskManagerGateway(taskManagerGateway);
+
+		for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
+			for (ExecutionVertex ev : ejv.getTaskVertices()) {
+				final LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+				final Execution execution = ev.getCurrentExecutionAttempt();
+				execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
+				if (!execution.tryAssignResource(slot)) {
+					throw new RuntimeException("Error when assigning slot to execution.");
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+/**
+ * The benchmark of deploying tasks in a STREAMING job.
+ * The related method is {@link Execution#deploy}.
+ */
+public class DeployingTasksInStreamingJobBenchmark extends DeployingTasksBenchmarkBase {
+
+	@Param("STREAMING")
+	private JobConfiguration jobConfiguration;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(DeployingTasksInStreamingJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		createAndSetupExecutionGraph(jobConfiguration);
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void deployAllTasks() throws Exception {
+		for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
+			for (ExecutionVertex ev : ejv.getTaskVertices()) {
+				Execution execution = ev.getCurrentExecutionAttempt();
+				execution.deploy();
+			}
+		}
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/FailoverBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/FailoverBenchmarkBase.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/**
+ * The base class of benchmarks related to failover.
+ */
+public class FailoverBenchmarkBase extends SchedulerBenchmarkBase {
+
+	JobVertex source;
+	List<JobVertex> jobVertices;
+
+	ExecutionGraph executionGraph;
+	SchedulingTopology schedulingTopology;
+	RestartPipelinedRegionFailoverStrategy strategy;
+
+	Set<ExecutionVertexID> tasks;
+
+	public void createRestartPipelinedRegionFailoverStrategy(JobConfiguration jobConfiguration) throws Exception {
+		jobVertices = createDefaultJobVertices(jobConfiguration);
+		source = jobVertices.get(0);
+		executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+		schedulingTopology = executionGraph.getSchedulingTopology();
+		strategy = new RestartPipelinedRegionFailoverStrategy(schedulingTopology);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.deployTasks;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.transitionTaskStatus;
+
+/**
+ * The benchmark of calculating the regions to restart when failover occurs in a BATCH job.
+ * The related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInBatchJobBenchmark extends FailoverBenchmarkBase {
+
+	@Param("BATCH")
+	private JobConfiguration jobConfiguration;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(RegionToRestartInBatchJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+
+		final JobVertex source = jobVertices.get(0);
+		final JobVertex sink = jobVertices.get(1);
+
+		final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+		deployTasks(executionGraph, source.getID(), slotBuilder, true);
+
+		transitionTaskStatus(executionGraph, source.getID(), ExecutionState.FINISHED);
+
+		deployTasks(executionGraph, sink.getID(), slotBuilder, true);
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void calculateRegionToRestart(Blackhole blackhole) {
+		tasks = strategy.getTasksNeedingRestart(
+				executionGraph.getJobVertex(source.getID()).getTaskVertices()[0].getID(),
+				new Exception("For test."));
+		blackhole.consume(tasks);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.switchAllVerticesToRunning;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.deployAllTasks;
+
+/**
+ * The benchmark of calculating region to restart when failover occurs in a STREAMING job.
+ * The related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInStreamingJobBenchmark extends FailoverBenchmarkBase {
+
+	@Param("STREAMING")
+	private JobConfiguration jobConfiguration;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(RegionToRestartInStreamingJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+
+		TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+		deployAllTasks(executionGraph, slotBuilder);
+
+		switchAllVerticesToRunning(executionGraph);
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void calculateRegionToRestart(Blackhole blackhole) {
+		tasks = strategy.getTasksNeedingRestart(
+				executionGraph.getJobVertex(source.getID()).getTaskVertices()[0].getID(),
+				new Exception("For test."));
+		blackhole.consume(tasks);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.partitionrelease;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.RegionPartitionReleaseStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.List;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.deployTasks;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.transitionTaskStatus;
+
+/**
+ * The benchmark of releasing partitions in a BATCH job.
+ * The related method is {@link RegionPartitionReleaseStrategy#vertexFinished}.
+ */
+public class PartitionReleaseInBatchJobBenchmark extends SchedulerBenchmarkBase {
+
+	@Param("BATCH")
+	private JobConfiguration jobConfiguration;
+
+	private ExecutionGraph executionGraph;
+	private JobVertex sink;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(PartitionReleaseInBatchJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		final List<JobVertex> jobVertices = createDefaultJobVertices(jobConfiguration);
+
+		executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+
+		final JobVertex source = jobVertices.get(0);
+		sink = jobVertices.get(1);
+
+		final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+		deployTasks(executionGraph, source.getID(), slotBuilder, true);
+
+		transitionTaskStatus(executionGraph, source.getID(), ExecutionState.FINISHED);
+
+		deployTasks(executionGraph, sink.getID(), slotBuilder, true);
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void partitionRelease() {
+		transitionTaskStatus(executionGraph, sink.getID(), ExecutionState.FINISHED);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+/**
+ * The benchmark of initializing {@link PipelinedRegionSchedulingStrategy} in a STREAMING/BATCH job.
+ */
+public class InitSchedulingStrategyBenchmark extends SchedulingBenchmarkBase {
+
+	@Param({"BATCH", "STREAMING"})
+	private JobConfiguration jobConfiguration;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(InitSchedulingStrategyBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		initSchedulingTopology(jobConfiguration);
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void initSchedulingStrategy(Blackhole blackhole) {
+		final PipelinedRegionSchedulingStrategy schedulingStrategy =
+				new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
+		blackhole.consume(schedulingStrategy);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulerOperations;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+
+import java.util.List;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/**
+ * The base class of benchmarks related to scheduling tasks.
+ */
+public class SchedulingBenchmarkBase extends SchedulerBenchmarkBase {
+
+	TestingSchedulerOperations schedulerOperations;
+	List<JobVertex> jobVertices;
+	ExecutionGraph executionGraph;
+	SchedulingTopology schedulingTopology;
+
+	public void initSchedulingTopology(JobConfiguration jobConfiguration) throws Exception {
+		schedulerOperations = new TestingSchedulerOperations();
+		jobVertices = createDefaultJobVertices(jobConfiguration);
+		executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+		schedulingTopology = executionGraph.getSchedulingTopology();
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The benchmark of scheduling downstream task in a BATCH job.
+ * The related method is {@link PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
+ */
+public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenchmarkBase {
+
+	@Param({"BATCH"})
+	private JobConfiguration jobConfiguration;
+
+	private ExecutionVertexID executionVertexID;
+	private PipelinedRegionSchedulingStrategy schedulingStrategy;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(SchedulingDownstreamTasksInBatchJobBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		initSchedulingTopology(jobConfiguration);
+
+		schedulingStrategy = new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
+
+		// When we trying to scheduling downstream tasks via onExecutionStateChange(ExecutionState.FINISHED),
+		// the result partitions of upstream tasks need to be CONSUMABLE.
+		// The CONSUMABLE status is determined by the variable "numberOfRunningProducers" of the IntermediateResult.
+		// Its value cannot be changed by any public methods.
+		// So here we use reflections to modify this value and then schedule the downstream tasks.
+		for (IntermediateResult result : executionGraph.getAllIntermediateResults().values()) {
+			Field f = result.getClass().getDeclaredField("numberOfRunningProducers");
+			f.setAccessible(true);
+			AtomicInteger numberOfRunningProducers = (AtomicInteger) f.get(result);
+			numberOfRunningProducers.set(0);
+		}
+
+		executionVertexID = executionGraph.getJobVertex(jobVertices.get(0).getID()).getTaskVertices()[0].getID();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void schedulingDownstreamTasks() {
+		schedulingStrategy.onExecutionStateChange(executionVertexID, ExecutionState.FINISHED);
+	}
+}

--- a/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.scheduler.benchmark.topology;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.List;
+
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+import static org.apache.flink.scheduler.benchmark.SchedulerBenchmarkUtils.createJobGraph;
+
+/**
+ * The benchmark of building the topology of {@link ExecutionGraph} in a STREAMING/BATCH job.
+ * The related method is {@link ExecutionGraph#attachJobGraph},
+ */
+public class BuildExecutionGraphBenchmark extends SchedulerBenchmarkBase {
+
+	private List<JobVertex> jobVertices;
+	private ExecutionGraph executionGraph;
+
+	@Param({"BATCH", "STREAMING"})
+	private JobConfiguration jobConfiguration;
+
+	public static void main(String[] args) throws RunnerException {
+		runBenchmark(BuildExecutionGraphBenchmark.class);
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		jobVertices = createDefaultJobVertices(jobConfiguration);
+		final JobGraph jobGraph = createJobGraph(jobConfiguration);
+		executionGraph = TestingExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	public void buildTopology() throws Exception {
+		executionGraph.attachJobGraph(jobVertices);
+	}
+}


### PR DESCRIPTION
This pull request introduces several benchmarks to evaluate the performance of the scheduler. For now it includes four procedures:

 - Topology building
 - Scheduling
 - Task deploying
 - Calculating the tasks to restart when failover
 - Partition releasing

All the topologies of the benchmarks consist of two vertices: one source vertex and one sink vertex. They are connected with all-to-all edges. The parallelisms of all vertices are 4k. There are two scenarios: 

 - For the streaming job, the result partition type is `PIPELINED`, and the execution mode is `STREAMING`.
 - For the batch job, the result partition type is `BLOCKING` , and the execution mode is `BATCH`.

It's worth noting that, for batch jobs, the sink tasks are scheduled and deployed if and only if all the source tasks finish. So the scheduling and deployment of source tasks and sink tasks have separated benchmarks. 

Since these procedures only executes once during the entire job, we use the cold start time to evaluate these procedures.