### PR TITLE
[FLINK-23078] Fix SchedulerBenchmarkExecutorBase#teardown

### DIFF
--- a/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkExecutorBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkExecutorBase.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 		"-Dcom.sun.management.jmxremote.ssl=false",
 		"-Dcom.sun.management.jmxremote.ssl"
 })
-public class SchedulerBenchmarkBase {
+public class SchedulerBenchmarkExecutorBase {
 
 	public static void runBenchmark(Class<?> clazz) throws RunnerException {
 		Options options = new OptionsBuilder()

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkExecutor.java
@@ -21,7 +21,7 @@ package org.apache.flink.scheduler.benchmark.deploying;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.deploying.DeployingDownstreamTasksInBatchJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -35,7 +35,7 @@ import org.openjdk.jmh.runner.RunnerException;
  * The benchmark of deploying downstream tasks in a BATCH job.
  * The related method is {@link Execution#deploy}.
  */
-public class DeployingDownstreamTasksInBatchJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class DeployingDownstreamTasksInBatchJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param("BATCH")
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkExecutor.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
@@ -56,5 +57,10 @@ public class DeployingDownstreamTasksInBatchJobBenchmarkExecutor extends Schedul
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void deployDownstreamTasks() throws Exception {
 		benchmark.deployDownstreamTasks();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkExecutor.java
@@ -21,7 +21,7 @@ package org.apache.flink.scheduler.benchmark.deploying;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.deploying.DeployingTasksInStreamingJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -35,7 +35,7 @@ import org.openjdk.jmh.runner.RunnerException;
  * The benchmark of deploying tasks in a STREAMING job.
  * The related method is {@link Execution#deploy}.
  */
-public class DeployingTasksInStreamingJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class DeployingTasksInStreamingJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param("STREAMING")
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkExecutor.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
@@ -56,5 +57,10 @@ public class DeployingTasksInStreamingJobBenchmarkExecutor extends SchedulerBenc
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void deployAllTasks() throws Exception {
 		benchmark.deployAllTasks();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/e2e/CreateSchedulerBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/e2e/CreateSchedulerBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.e2e;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.e2e.CreateSchedulerBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -35,7 +35,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of creating the scheduler in a STREAMING/BATCH job.
  */
-public class CreateSchedulerBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class CreateSchedulerBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param({"BATCH", "STREAMING"})
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/e2e/CreateSchedulerBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/e2e/CreateSchedulerBenchmarkExecutor.java
@@ -59,7 +59,7 @@ public class CreateSchedulerBenchmarkExecutor extends SchedulerBenchmarkExecutor
 	}
 
 	@TearDown(Level.Trial)
-	public void teardownTrial() throws Exception {
+	public void teardown() {
 		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkExecutor.java
@@ -58,7 +58,7 @@ public class SchedulingAndDeployingBenchmarkExecutor extends SchedulerBenchmarkE
 	}
 
 	@TearDown(Level.Trial)
-	public void teardownTrial() throws Exception {
+	public void teardown() {
 		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.e2e;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.e2e.SchedulingAndDeployingBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -34,7 +34,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of scheduling and deploying tasks in a STREAMING/BATCH job.
  */
-public class SchedulingAndDeployingBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class SchedulingAndDeployingBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param({"BATCH", "STREAMING"})
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkExecutor.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.RunnerException;
 
@@ -55,5 +56,10 @@ public class RegionToRestartInBatchJobBenchmarkExecutor extends SchedulerBenchma
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void calculateRegionToRestart(Blackhole blackhole) {
 		blackhole.consume(benchmark.calculateRegionToRestart());
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.failover;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.failover.RegionToRestartInBatchJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -34,7 +34,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of calculating the regions to restart when failover occurs in a BATCH job.
  */
-public class RegionToRestartInBatchJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class RegionToRestartInBatchJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param("BATCH")
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkExecutor.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.RunnerException;
 
@@ -55,5 +56,10 @@ public class RegionToRestartInStreamingJobBenchmarkExecutor extends SchedulerBen
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void calculateRegionToRestart(Blackhole blackhole) {
 		blackhole.consume(benchmark.calculateRegionToRestart());
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.failover;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.failover.RegionToRestartInStreamingJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -34,7 +34,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of calculating region to restart when failover occurs in a STREAMING job.
  */
-public class RegionToRestartInStreamingJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class RegionToRestartInStreamingJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param("STREAMING")
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.scheduler.benchmark.partitionrelease;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils;
 import org.apache.flink.runtime.scheduler.benchmark.partitionrelease.PartitionReleaseInBatchJobBenchmark;
 import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
@@ -28,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
@@ -54,5 +56,10 @@ public class PartitionReleaseInBatchJobBenchmarkExecutor extends SchedulerBenchm
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void partitionRelease() {
 		benchmark.partitionRelease();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.partitionrelease;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.partitionrelease.PartitionReleaseInBatchJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -33,7 +33,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of releasing partitions in a BATCH job.
  */
-public class PartitionReleaseInBatchJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class PartitionReleaseInBatchJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param("BATCH")
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils;
 import org.apache.flink.runtime.scheduler.benchmark.scheduling.InitSchedulingStrategyBenchmark;
 import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
@@ -28,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.RunnerException;
 
@@ -55,5 +57,10 @@ public class InitSchedulingStrategyBenchmarkExecutor extends SchedulerBenchmarkE
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void initSchedulingStrategy(Blackhole blackhole) {
 		blackhole.consume(benchmark.initSchedulingStrategy());
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.scheduling.InitSchedulingStrategyBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -34,7 +34,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of initializing the scheduling strategy in a STREAMING/BATCH job.
  */
-public class InitSchedulingStrategyBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class InitSchedulingStrategyBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param({"BATCH", "STREAMING"})
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.scheduling.SchedulingDownstreamTasksInBatchJobBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -33,7 +33,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of scheduling downstream task in a BATCH job.
  */
-public class SchedulingDownstreamTasksInBatchJobBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class SchedulingDownstreamTasksInBatchJobBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param({"BATCH"})
 	private JobConfiguration jobConfiguration;

--- a/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils;
 import org.apache.flink.runtime.scheduler.benchmark.scheduling.SchedulingDownstreamTasksInBatchJobBenchmark;
 import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
@@ -28,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
@@ -54,5 +56,10 @@ public class SchedulingDownstreamTasksInBatchJobBenchmarkExecutor extends Schedu
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void schedulingDownstreamTasks() {
 		benchmark.schedulingDownstreamTasks();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.scheduler.benchmark.topology;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils;
 import org.apache.flink.runtime.scheduler.benchmark.topology.BuildExecutionGraphBenchmark;
 import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
@@ -28,6 +29,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
@@ -54,5 +56,10 @@ public class BuildExecutionGraphBenchmarkExecutor extends SchedulerBenchmarkExec
 	@BenchmarkMode(Mode.SingleShotTime)
 	public void buildTopology() throws Exception {
 		benchmark.buildTopology();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() {
+		benchmark.teardown();
 	}
 }

--- a/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkExecutor.java
@@ -20,7 +20,7 @@ package org.apache.flink.scheduler.benchmark.topology;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.topology.BuildExecutionGraphBenchmark;
-import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkBase;
+import org.apache.flink.scheduler.benchmark.SchedulerBenchmarkExecutorBase;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -33,7 +33,7 @@ import org.openjdk.jmh.runner.RunnerException;
 /**
  * The benchmark of building the topology of ExecutionGraph in a STREAMING/BATCH job.
  */
-public class BuildExecutionGraphBenchmarkExecutor extends SchedulerBenchmarkBase {
+public class BuildExecutionGraphBenchmarkExecutor extends SchedulerBenchmarkExecutorBase {
 
 	@Param({"BATCH", "STREAMING"})
 	private JobConfiguration jobConfiguration;


### PR DESCRIPTION
In FLINK-22988, TestUtils are ported from Scala to Java. However, `SchedulerBenchmarkBase` in flink-benchmark calls this method when each benchmark teardowns. This make SchedulerBenchmarks not compiling, as FLINK-23078 says. To solve this issue, we'd like to wrap `TestingUtils.defaultExecutor().shutdownNow()` into `SchedulerBenchmarkUtil`. If this method is changed in the future, its reference must be fixed, too. 

Furthermore, it's confusing to have `SchedulerBenchmarkBase` in both flink and flink-benchmark. So I'd like to propose change `SchedulerBenchmarkBase` into `SchedulerBenchmarkExecutorBase` in flink-benchmark.

### Brief changelog

* Change `TestingUtils.defaultExecutor().shutdownNow()` into `SchedulerBenchmarkUtil#shutdownTestingUtilDefaultExecutor`.