### PR TITLE
[FLINK-23153] Fix the reference of FutureUtils in RecordSource

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/operators/RecordSource.java
+++ b/src/main/java/org/apache/flink/benchmark/operators/RecordSource.java
@@ -31,7 +31,6 @@ import org.apache.flink.benchmark.operators.RecordSource.EmptySplit;
 import org.apache.flink.benchmark.operators.RecordSource.Record;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
 
@@ -131,7 +130,7 @@ public class RecordSource implements Source<Record, EmptySplit, EmptyEnumeratorS
 
         @Override
         public CompletableFuture<Void> isAvailable() {
-            return FutureUtils.completedVoidFuture();
+            return CompletableFuture.completedFuture(null);
         }
 
         @Override


### PR DESCRIPTION
In FLINK-23085, FutureUtils is moved from flink-runtime to flink-core. The reference in flink-benchmark should also be changed. The reference is located at: org/apache/flink/benchmark/operators/RecordSource.java.