### PR TITLE
[FLINK-23383] Prevent duplicate setUp/tearDown calls 

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
@@ -87,6 +87,7 @@ public class BlockingPartitionBenchmark extends BenchmarkBase {
 		 */
 		private final int parallelism = 4;
 
+		@Override
 		public void setUp() throws IOException {
 			super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
@@ -87,7 +87,6 @@ public class BlockingPartitionBenchmark extends BenchmarkBase {
 		 */
 		private final int parallelism = 4;
 
-		@Setup
 		public void setUp() throws IOException {
 			super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
@@ -66,7 +66,6 @@ public class BlockingPartitionRemoteChannelBenchmark extends RemoteBenchmarkBase
      */
     public static class BlockingPartitionEnvironmentContext extends FlinkEnvironmentContext {
 
-        @Setup
         public void setUp() throws IOException {
             super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
@@ -66,6 +66,7 @@ public class BlockingPartitionRemoteChannelBenchmark extends RemoteBenchmarkBase
      */
     public static class BlockingPartitionEnvironmentContext extends FlinkEnvironmentContext {
 
+        @Override
         public void setUp() throws IOException {
             super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
@@ -63,14 +63,8 @@ public class MemoryStateBackendBenchmark extends StateBackendBenchmarkBase {
 		@Param({"MEMORY", "FS", "FS_ASYNC"})
 		public StateBackend stateBackend = StateBackend.MEMORY;
 
-		@Setup
 		public void setUp() throws IOException {
 			super.setUp(stateBackend, RECORDS_PER_INVOCATION);
-		}
-
-		@TearDown
-		public void tearDown() throws IOException {
-			super.tearDown();
 		}
 	}
 }

--- a/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
@@ -63,6 +63,7 @@ public class MemoryStateBackendBenchmark extends StateBackendBenchmarkBase {
 		@Param({"MEMORY", "FS", "FS_ASYNC"})
 		public StateBackend stateBackend = StateBackend.MEMORY;
 
+		@Override
 		public void setUp() throws IOException {
 			super.setUp(stateBackend, RECORDS_PER_INVOCATION);
 		}

--- a/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
@@ -66,14 +66,8 @@ public class RocksStateBackendBenchmark extends StateBackendBenchmarkBase {
 		@Param({"ROCKS", "ROCKS_INC"})
 		public StateBackend stateBackend = StateBackend.MEMORY;
 
-		@Setup
 		public void setUp() throws IOException {
 			super.setUp(stateBackend, RECORDS_PER_INVOCATION);
-		}
-
-		@TearDown
-		public void tearDown() throws IOException {
-			super.tearDown();
 		}
 
 		@Override

--- a/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
@@ -66,6 +66,7 @@ public class RocksStateBackendBenchmark extends StateBackendBenchmarkBase {
 		@Param({"ROCKS", "ROCKS_INC"})
 		public StateBackend stateBackend = StateBackend.MEMORY;
 
+		@Override
 		public void setUp() throws IOException {
 			super.setUp(stateBackend, RECORDS_PER_INVOCATION);
 		}

--- a/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
@@ -94,7 +94,6 @@ public class UnalignedCheckpointTimeBenchmark extends BenchmarkBase {
         @Param({"0", "1", "ALIGNED"})
         public String timeout = "0";
 
-        @Setup
         public void setUp() throws IOException {
             super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
@@ -94,6 +94,7 @@ public class UnalignedCheckpointTimeBenchmark extends BenchmarkBase {
         @Param({"0", "1", "ALIGNED"})
         public String timeout = "0";
 
+        @Override
         public void setUp() throws IOException {
             super.setUp();
 

--- a/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
@@ -83,7 +83,6 @@ public class WindowBenchmarks extends BenchmarkBase {
 
 		public DataStreamSource<IntegerLongSource.Record> source;
 
-		@Setup
 		@Override
 		public void setUp() throws IOException {
 			super.setUp();


### PR DESCRIPTION
Prevents an issue where `FlinkEnvironmentContext#setUp/tearDown` would be called multiple times, because subclasses contained overrides annotated with `@SetUp/@TearDown` which called into the parent version.

The effect can be easily seen by adding some `println` statements to `FlinkEnvironmentContext#setUp` and running the `WindowBenchmarks` (or any benchmark with a `FlinkEnvironmentContext` subclass).