### PR TITLE
[FLINK-23392] Exclude startup/shutdown time from benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<!-- required for using a pre-defined MiniCluster -->
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>

--- a/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
+++ b/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
@@ -54,7 +54,10 @@ public class FlinkEnvironmentContext {
             throw new RuntimeException("setUp was called multiple times!");
         }
         final Configuration clusterConfig = createConfiguration();
-        miniCluster = new MiniCluster(new MiniClusterConfiguration.Builder().setConfiguration(clusterConfig).build());
+        miniCluster = new MiniCluster(new MiniClusterConfiguration.Builder()
+            .setNumSlotsPerTaskManager(4)
+            .setConfiguration(clusterConfig)
+            .build());
         try {
             miniCluster.start();
         } catch (Exception e) {

--- a/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
+++ b/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
@@ -55,9 +55,11 @@ public class FlinkEnvironmentContext {
         }
         final Configuration clusterConfig = createConfiguration();
         miniCluster = new MiniCluster(new MiniClusterConfiguration.Builder()
-            .setNumSlotsPerTaskManager(4)
+            .setNumSlotsPerTaskManager(getNumberOfSlotsPerTaskManager())
+            .setNumTaskManagers(getNumberOfTaskManagers())
             .setConfiguration(clusterConfig)
             .build());
+
         try {
             miniCluster.start();
         } catch (Exception e) {
@@ -81,6 +83,14 @@ public class FlinkEnvironmentContext {
     public void tearDown() throws Exception {
         miniCluster.close();
         miniCluster = null;
+    }
+
+    protected int getNumberOfTaskManagers() {
+        return 1;
+    }
+
+    protected int getNumberOfSlotsPerTaskManager() {
+        return 4;
     }
 
     public void execute() throws Exception {

--- a/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
@@ -109,11 +109,19 @@ public class UnalignedCheckpointTimeBenchmark extends BenchmarkBase {
             }
         }
 
+        @Override
+        protected int getNumberOfSlotsPerTaskManager() {
+            return 1;
+        }
+
+        @Override
+        protected int getNumberOfTaskManagers() {
+            return NUM_VERTICES * PARALLELISM;
+        }
+
         protected Configuration createConfiguration() {
             Configuration conf = super.createConfiguration();
-            conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
             conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, new MemorySize(1024 * 4));
-            conf.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_VERTICES * PARALLELISM);
             return conf;
         }
     }

--- a/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/UnalignedCheckpointTimeBenchmark.java
@@ -116,6 +116,7 @@ public class UnalignedCheckpointTimeBenchmark extends BenchmarkBase {
 
         @Override
         protected int getNumberOfTaskManagers() {
+            // why is this using PARALLELISM when we don't actually use it?
             return NUM_VERTICES * PARALLELISM;
         }
 


### PR DESCRIPTION
Sets up a MiniCluster in the `FlinkEnvironmentContext`, which all jobs will be run against.