### PR TITLE
[FLINK-23398] Exclude signature files from shaded benchmarks.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@ under the License.
 									</transformers>
 									<filters>
 										<filter>
-											<artifact>*:*</artifact>
+											<artifact>*</artifact>
 											<excludes>
 												<exclude>META-INF/*.SF</exclude>
 												<exclude>META-INF/*.DSA</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,16 @@ under the License.
 		                                                                        <projectName>Apache Flink</projectName>
 		                                                                </transformer>
 									</transformers>
+									<filters>
+										<filter>
+											<artifact>*:*</artifact>
+											<excludes>
+												<exclude>META-INF/*.SF</exclude>
+												<exclude>META-INF/*.DSA</exclude>
+												<exclude>META-INF/*.RSA</exclude>
+											</excludes>
+										</filter>
+									</filters>
 								</configuration>
 							</execution>
 						</executions>


### PR DESCRIPTION
This fix current check when running benchmarks on the shaded jar package.