### PR TITLE
[FLINK-23491] Update flink-runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>1.14-SNAPSHOT</flink.version>
-		<flink.shaded.version>10.0</flink.shaded.version>
-		<netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
+		<flink.shaded.version>14.0</flink.shaded.version>
+		<netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
-			<version>${flink.version}</version>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 			<type>test-jar</type>

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
@@ -100,7 +100,7 @@ public class BlockingPartitionBenchmark extends BenchmarkBase {
 
 			configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, compressionEnabled);
 			configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, subpartitionType);
-			configuration.setString(CoreOptions.TMP_DIRS, FileUtils.getCurrentWorkingDirectory().toAbsolutePath().toUri().toString());
+			configuration.setString(CoreOptions.TMP_DIRS, FileUtils.getCurrentWorkingDirectory().toAbsolutePath().toString());
 			return configuration;
 		}
 	}

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
@@ -79,7 +79,7 @@ public class BlockingPartitionRemoteChannelBenchmark extends RemoteBenchmarkBase
             Configuration configuration = super.createConfiguration();
 
             configuration.setString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
-            configuration.setString(CoreOptions.TMP_DIRS, FileUtils.getCurrentWorkingDirectory().toAbsolutePath().toUri().toString());
+            configuration.setString(CoreOptions.TMP_DIRS, FileUtils.getCurrentWorkingDirectory().toAbsolutePath().toString());
             return configuration;
         }
     }


### PR DESCRIPTION
Removes the scala suffix from the flink-runtime dependency, which is required because flink-runtime on master is now scala-free.

Because of the suffix the benchmarks were using an old snapshot test-jar, which referenced classes that no longer exist.

Note that CI may fail because Flink snapshots are currently broken.