### PR TITLE
[FLINK-23689] Increase ProcessingTimerBenchmark length

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
@@ -38,7 +38,7 @@ import java.util.Random;
 @OperationsPerInvocation(value = ProcessingTimerBenchmark.PROCESSING_TIMERS_PER_INVOCATION)
 public class ProcessingTimerBenchmark extends BenchmarkBase {
 
-    public static final int PROCESSING_TIMERS_PER_INVOCATION = 1_000;
+    public static final int PROCESSING_TIMERS_PER_INVOCATION = 150_000;
 
     private static final int PARALLELISM = 1;
 

--- a/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.util.Collector;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.runner.Runner;
@@ -43,12 +44,12 @@ public class ProcessingTimerBenchmark extends BenchmarkBase {
 
     private static OneShotLatch LATCH = new OneShotLatch();
 
-    public static void main(String[] args)
-            throws RunnerException {
-        Options options = new OptionsBuilder()
-                .verbosity(VerboseMode.NORMAL)
-                .include(".*" + ProcessingTimerBenchmark.class.getCanonicalName() + ".*")
-                .build();
+    public static void main(String[] args) throws RunnerException {
+        Options options =
+                new OptionsBuilder()
+                        .verbosity(VerboseMode.NORMAL)
+                        .include(".*" + ProcessingTimerBenchmark.class.getCanonicalName() + ".*")
+                        .build();
 
         new Runner(options).run();
     }
@@ -91,7 +92,8 @@ public class ProcessingTimerBenchmark extends BenchmarkBase {
         public void cancel() {}
     }
 
-    private static class ProcessingTimerKeyedProcessFunction extends KeyedProcessFunction<Integer, String, String> {
+    private static class ProcessingTimerKeyedProcessFunction
+            extends KeyedProcessFunction<Integer, String, String> {
 
         private final long timersPerRecord;
         private long firedTimesCount;
@@ -106,7 +108,8 @@ public class ProcessingTimerBenchmark extends BenchmarkBase {
         }
 
         @Override
-        public void processElement(String s, Context context, Collector<String> collector) throws Exception {
+        public void processElement(String s, Context context, Collector<String> collector)
+                throws Exception {
             final long currTimestamp = System.currentTimeMillis();
             for (int i = 0; i < timersPerRecord; i++) {
                 context.timerService().registerProcessingTimeTimer(currTimestamp - i - 1);
@@ -114,7 +117,8 @@ public class ProcessingTimerBenchmark extends BenchmarkBase {
         }
 
         @Override
-        public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+        public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out)
+                throws Exception {
             if (++firedTimesCount == timersPerRecord) {
                 LATCH.trigger();
             }


### PR DESCRIPTION
Previous 1000 records was forced upon this benchmark because of
very slow production code. After resolving FLINK-23689 we can
safely increase number of records. Otherwise we would be testing
setup time of a Flink job.

