### PR TITLE
[hotfix] Upgrade to scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
 		<flink.shaded.version>14.0</flink.shaded.version>
 		<netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>
-		<scala.binary.version>2.11</scala.binary.version>
+		<scala.binary.version>2.12</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<slf4j.version>1.7.7</slf4j.version>


### PR DESCRIPTION
In Flink 1.15 we will drop scala 2.11. Therefore we should upgrade
benchmarks to scala 2.12 as well.