### PR TITLE
[FLINK-25556] Disabled the waiting for final checkpoint for all benchmarks.

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
+++ b/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterPipelineExecutorServiceLoader;
 
@@ -103,6 +104,9 @@ public class FlinkEnvironmentContext {
                 NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, NUM_NETWORK_BUFFERS);
         configuration.set(DeploymentOptions.TARGET, MiniClusterPipelineExecutorServiceLoader.NAME);
         configuration.set(DeploymentOptions.ATTACHED, true);
+        // It doesn't make sense to wait for the final checkpoint in benchmarks since it only prolongs
+        // the test but doesn't give any advantages.
+        configuration.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, false);
         return configuration;
     }
 }


### PR DESCRIPTION
This PR disables ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH for all benchamrks.