### PR TITLE
[FLINK-25704] Fix the blocking partition benchmark regression caused by FLINK-25637

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
@@ -95,6 +95,9 @@ public class BlockingPartitionBenchmark extends BenchmarkBase {
                 boolean compressionEnabled, String subpartitionType) {
             Configuration configuration = super.createConfiguration();
 
+            configuration.setInteger(
+                    NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
+                    Integer.MAX_VALUE);
             configuration.setBoolean(
                     NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED,
                     compressionEnabled);

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionRemoteChannelBenchmark.java
@@ -71,6 +71,9 @@ public class BlockingPartitionRemoteChannelBenchmark extends RemoteBenchmarkBase
         protected Configuration createConfiguration() {
             Configuration configuration = super.createConfiguration();
 
+            configuration.setInteger(
+                    NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
+                    Integer.MAX_VALUE);
             configuration.setString(
                     NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
             configuration.setString(


### PR DESCRIPTION
FLINK-25637 changed the default blocking shuffle implementation from hash-shuffle to sort-shuffle which caused some benchmark regression. This PR tries to fix the regression. For more information about the regression, please refer to https://issues.apache.org/jira/browse/FLINK-25704.