### PR TITLE
[FLINK-27214] Fix rescaling benchmark build failed

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/HashMapStateBackendRescalingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/state/benchmark/HashMapStateBackendRescalingBenchmarkExecutor.java
@@ -67,7 +67,7 @@ public class HashMapStateBackendRescalingBenchmarkExecutor extends RescalingBenc
         benchmark.setUp();
     }
 
-    @Setup(Level.Iteration)
+    @Setup(Level.Invocation)
     public void setUpPerInvocation() throws Exception {
         benchmark.prepareStateForOperator(rescaleType.getSubtaskIndex());
     }
@@ -82,7 +82,7 @@ public class HashMapStateBackendRescalingBenchmarkExecutor extends RescalingBenc
         benchmark.rescale();
     }
 
-    @TearDown(Level.Iteration)
+    @TearDown(Level.Invocation)
     public void tearDownPerInvocation() throws Exception {
         benchmark.closeOperator();
     }

--- a/src/main/java/org/apache/flink/state/benchmark/RocksdbStateBackendRescalingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/state/benchmark/RocksdbStateBackendRescalingBenchmarkExecutor.java
@@ -66,7 +66,7 @@ public class RocksdbStateBackendRescalingBenchmarkExecutor extends RescalingBenc
         benchmark.setUp();
     }
 
-    @Setup(Level.Iteration)
+    @Setup(Level.Invocation)
     public void setUpPerInvocation() throws Exception {
         benchmark.prepareStateForOperator(rescaleType.getSubtaskIndex());
     }
@@ -81,7 +81,7 @@ public class RocksdbStateBackendRescalingBenchmarkExecutor extends RescalingBenc
         benchmark.rescale();
     }
 
-    @TearDown(Level.Iteration)
+    @TearDown(Level.Invocation)
     public void tearDownPerInvocation() throws Exception {
         benchmark.closeOperator();
     }


### PR DESCRIPTION
In `Iteration` level, `initializeState()` may be called repeatedly without setup, which causes build failed. So, change the level of `Setup/TearDown` in the rescaling benchmark from `Iteration` to `Invocation`.

Here is the exception message:
```
java.lang.IllegalStateException: TestHarness has already been initialized. Have you opened this harness before initializing it?
        at org.apache.flink.util.Preconditions.checkState(Preconditions.java:193)
        at org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness.initializeState(AbstractStreamOperatorTestHarness.java:573)
        at org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness.initializeState(AbstractStreamOperatorTestHarness.java:466)
        at org.apache.flink.contrib.streaming.state.benchmark.RescalingBenchmark.rescale(RescalingBenchmark.java:87)
        at org.apache.flink.state.benchmark.RocksdbStateBackendRescalingBenchmarkExecutor.rescaleRocksDB(RocksdbStateBackendRescalingBenchmarkExecutor.java:81)
        at org.apache.flink.state.benchmark.generated.RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.rescaleRocksDB_avgt_jmhStub(RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.java:192)
        at org.apache.flink.state.benchmark.generated.RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.rescaleRocksDB_AverageTime(RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.java:154)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

We can see that what is actually being executed is the compiled `RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.java`. In the compiled file, the benchmark method `rescaleRocksDB()` is in a while loop, it would be executed multi times,  but the `setUpPerInvocation()` method only executes once before the loop. Thus the `Iteration` level is not suitable.

```
 public BenchmarkTaskResult rescaleRocksDB_AverageTime(InfraControl control, ThreadParams threadParams) throws Throwable {
        ...
            control.preSetup();
            l_rocksdbstatebackendrescalingbenchmarkexecutor0_0.setUpPerInvocation();
            control.announceWarmupReady();
            while (control.warmupShouldWait) {
                l_rocksdbstatebackendrescalingbenchmarkexecutor0_0.rescaleRocksDB();
                res.allOps++;
            }
       ...
}
```