### PR TITLE
[FLINK-27571][benchmark] Recognize 'less is better' benchmarks in regression detection script

### DIFF
--- a/save_jmh_result.py
+++ b/save_jmh_result.py
@@ -66,6 +66,8 @@ def readData(args):
         paramIndexes = map(lambda param : header.index(param), params)
         benchmarkIndex = header.index("Benchmark")
         scoreIndex = header.index("Score")
+        modeIndex = header.index("Mode")
+        unitIndex = header.index("Unit")
         errorIndex = scoreIndex + 1
 
         for line in lines[1:]:
@@ -74,7 +76,12 @@ def readData(args):
                 for paramIndex in paramIndexes:
                     if len(line[paramIndex]) > 0:
                         name += "." + line[paramIndex]
-
+            lessIsBetter = (line[modeIndex] == "avgt" or line[modeIndex] == "ss")
+            # unitsTitle is used to distinguish different groups of benchmarks when getting changes
+            # see https://github.com/tobami/codespeed/blob/263860bc298fd970c8466b3161de386582e4f801/codespeed/models.py#L444
+            unitsTitle = "Time"
+            if lessIsBetter:
+                unitsTitle = "Times"
             results.append({
                 'commitid': args.commit,
                 'branch': args.branch,
@@ -82,8 +89,9 @@ def readData(args):
                 'executable': args.executable,
                 'benchmark': name,
                 'environment': args.environment,
-                'lessisbetter': False,
-                'units': 'records/ms',
+                'lessisbetter': lessIsBetter,
+                'units': line[unitIndex],
+                'units_title': unitsTitle,
                 'result_value': float(line[scoreIndex]),
 
                 'revision_date': str(modificationDate),


### PR DESCRIPTION
1. Add the script that updates fields for codespeed_benchmark table. After updating, the Y axis  would become “ms/op (less is better)”, e.g. [rescaleHeap](http://codespeed.dak8s.net:8000/timeline/#/?ben=rescaleHeap.RESCALE_IN&extr=on&quarts=on&equid=off&env=2&revs=200&exe=1,3,5,6,8,9)
2. Update save_jmh_results.py , If a new benchmark is introduced, the `lessisbetter` and `units` fields of results would be determined by a new benchmark instead of hard-code.
3. Update regression_report.py to detect the "less is better" regression. 