### PR TITLE
[FLINK-30870][benchmark] Replace sending slack messages with attachments

### DIFF
--- a/jenkinsfiles/regression-check.jenkinsfile
+++ b/jenkinsfiles/regression-check.jenkinsfile
@@ -24,7 +24,13 @@ timestamps {
                     sh './regression_report.py > regression-report'
                     def alerts = readFile "regression-report"
                     if (alerts) {
-                         slackSend (message: "Performance regression\n$alerts", channel: "#flink-dev-benchmarks")
+                         def attachments = [
+                           [
+                             text: "Performance regression\n$alerts",
+                             fallback: "Performance regression",
+                           ]
+                         ]
+                         slackSend (attachments: attachments, channel: "#flink-dev-benchmarks")
                     }
                 }
             }


### PR DESCRIPTION
 Due to the[ limitation of the message length](https://github.com/jenkinsci/slack-plugin/issues/735#issuecomment-774131103) of slack plugin, the performance regressions notifications in Slack are cut off.  This PR replaces sending messages with sending attachments.