### PR TITLE
[FLINK-31965] Fix ClassNotFoundException in benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@ under the License.
 			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<type>test-jar</type>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The benchmarks rely on the test jar of `flink-streaming-java`. However, the jar is set to test scope, thus not included in the packaged jar. Therefore ClassNotFoundException occurs while running the benchmarks with `java --jar xxx` command.

```
java.lang.NoClassDefFoundError: org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness
at org.apache.flink.contrib.streaming.state.benchmark.RescalingBenchmark.prepareState(RescalingBenchmark.java:111)
at org.apache.flink.contrib.streaming.state.benchmark.RescalingBenchmark.setUp(RescalingBenchmark.java:78)
at org.apache.flink.state.benchmark.RocksdbStateBackendRescalingBenchmarkExecutor.setUp(RocksdbStateBackendRescalingBenchmarkExecutor.java:66)
at org.apache.flink.state.benchmark.generated.RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest._jmh_tryInit_f_rocksdbstatebackendrescalingbenchmarkexecutor0_0(RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.java:370)
at org.apache.flink.state.benchmark.generated.RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.rescaleRocksDB_AverageTime(RocksdbStateBackendRescalingBenchmarkExecutor_rescaleRocksDB_jmhTest.java:147)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
... 17 more
```