### PR TITLE
[FLINK-33033][olap][haservice] Add haservice micro benchmark for olap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@ under the License.
 		<chill.version>0.7.6</chill.version>
 		<thrift.version>0.13.0</thrift.version>
 		<protobuf.version>3.21.7</protobuf.version>
-		<curator.version>5.4.0</curator.version>
 		<netty-tcnative.flavor>dynamic</netty-tcnative.flavor>
 		<benchmarkExcludes>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*,org.apache.flink.scheduler.benchmark.*</benchmarkExcludes>
 		<benchmarks>.*</benchmarks>
@@ -107,6 +106,13 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${flink.version}</version>
 			<type>test-jar</type>
 		</dependency>
@@ -257,12 +263,6 @@ under the License.
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>${protobuf.version}</version>
-		</dependency>
-		<!-- Curator -->
-		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-test</artifactId>
-			<version>${curator.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@ under the License.
 		<chill.version>0.7.6</chill.version>
 		<thrift.version>0.13.0</thrift.version>
 		<protobuf.version>3.21.7</protobuf.version>
+		<curator.version>5.4.0</curator.version>
 		<netty-tcnative.flavor>dynamic</netty-tcnative.flavor>
 		<benchmarkExcludes>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*,org.apache.flink.scheduler.benchmark.*</benchmarkExcludes>
 		<benchmarks>.*</benchmarks>
@@ -256,6 +257,12 @@ under the License.
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>${protobuf.version}</version>
+		</dependency>
+		<!-- Curator -->
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/apache/flink/olap/benchmark/HighAvailabilityServiceBenchmark.java
+++ b/src/main/java/org/apache/flink/olap/benchmark/HighAvailabilityServiceBenchmark.java
@@ -97,26 +97,36 @@ public class HighAvailabilityServiceBenchmark extends BenchmarkBase {
 
 		@Override
 		public void setUp() throws Exception {
-			testingServer = new TestingServer();
-			testingServer.start();
+			if (isZookeeperHighAvailability()) {
+				testingServer = new TestingServer();
+				testingServer.start();
+			}
 
 			super.setUp();
+		}
+
+		private boolean isZookeeperHighAvailability() {
+			return highAvailabilityMode == HighAvailabilityMode.ZOOKEEPER;
 		}
 
 		@Override
 		protected Configuration createConfiguration() {
 			Configuration configuration = super.createConfiguration();
 			configuration.set(HighAvailabilityOptions.HA_MODE, highAvailabilityMode.name());
-			configuration.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 			configuration.set(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
+			if (isZookeeperHighAvailability()) {
+				configuration.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+			}
 			return configuration;
 		}
 
 		@Override
 		public void tearDown() throws Exception {
 			super.tearDown();
-			testingServer.stop();
-			testingServer.close();
+			if (isZookeeperHighAvailability()) {
+				testingServer.stop();
+				testingServer.close();
+			}
 			FileUtils.deleteDirectory(haDir);
 		}
 	}

--- a/src/main/java/org/apache/flink/olap/benchmark/HighAvailabilityServiceBenchmark.java
+++ b/src/main/java/org/apache/flink/olap/benchmark/HighAvailabilityServiceBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.olap.benchmark;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.benchmark.BenchmarkBase;
+import org.apache.flink.benchmark.FlinkEnvironmentContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.FileUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+/** The benchmark for submitting short-lived jobs with and without high availability service. */
+@OutputTimeUnit(SECONDS)
+public class HighAvailabilityServiceBenchmark extends BenchmarkBase {
+	public static void main(String[] args) throws RunnerException {
+		Options options =
+				new OptionsBuilder()
+						.verbosity(VerboseMode.NORMAL)
+						.include(".*" + HighAvailabilityServiceBenchmark.class.getCanonicalName() + ".*")
+						.build();
+
+		new Runner(options).run();
+	}
+
+	@Benchmark
+	public void submitJobThroughput(HighAvailabilityContext context) throws Exception {
+		context.miniCluster.executeJobBlocking(buildNoOpJob());
+	}
+
+	private JobGraph buildNoOpJob() {
+		JobGraph jobGraph = new JobGraph(JobID.generate(), UUID.randomUUID().toString());
+		jobGraph.addVertex(createNoOpVertex());
+		return jobGraph;
+	}
+
+	private JobVertex createNoOpVertex() {
+		JobVertex vertex = new JobVertex("v");
+		vertex.setInvokableClass(NoOpInvokable.class);
+		vertex.setParallelism(1);
+		vertex.setMaxParallelism(1);
+		return vertex;
+	}
+
+	@State(Thread)
+	public static class HighAvailabilityContext extends FlinkEnvironmentContext {
+		private TestingServer testingServer;
+		public final File haDir;
+
+		@Param({"ZOOKEEPER", "NONE"})
+		public HighAvailabilityMode highAvailabilityMode;
+
+		public HighAvailabilityContext() {
+			try {
+				haDir = Files.createTempDirectory("bench-ha-").toFile();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public void setUp() throws Exception {
+			testingServer = new TestingServer();
+			testingServer.start();
+
+			super.setUp();
+		}
+
+		@Override
+		protected Configuration createConfiguration() {
+			Configuration configuration = super.createConfiguration();
+			configuration.set(HighAvailabilityOptions.HA_MODE, highAvailabilityMode.name());
+			configuration.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+			configuration.set(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
+			return configuration;
+		}
+
+		@Override
+		public void tearDown() throws Exception {
+			super.tearDown();
+			testingServer.stop();
+			testingServer.close();
+			FileUtils.deleteDirectory(haDir);
+		}
+	}
+}


### PR DESCRIPTION
This PR aims to add high availability service micro benchmark for olap. It will compare the throughputs for none and zookeeper ha service in dispatcher to show that, the current high availability service should be divided into cluster and job high availability services, which have been discussed in https://issues.apache.org/jira/browse/FLINK-32667. Then we can configure none ha service for job when cluster ha service is needed in flink cluster to improve the performance for olap jobs.

The main work of this PR include:
1. Create a `MiniCluster` with `ZOOKEEPER` and `NONE` high availability services.
2. Create a job with one no-op vertex
3. Count the throughput of submitting jobs per second

The results show that the throughput with none HA is more than twice that of zookeeper HA. 
