### PR TITLE
[FLINK-33122][benchmark] Support null checkpoint data path for rescaling benchmarks

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/HashMapStateBackendRescalingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/state/benchmark/HashMapStateBackendRescalingBenchmarkExecutor.java
@@ -50,15 +50,13 @@ public class HashMapStateBackendRescalingBenchmarkExecutor extends RescalingBenc
     public void setUp() throws Exception {
         // FsStateBackend is deprecated in favor of HashMapStateBackend with setting checkpointStorage.
         HashMapStateBackend stateBackend = new HashMapStateBackend();
-        Configuration benchMarkConfig = ConfigUtil.loadBenchMarkConf();
-        String stateDataDirPath = benchMarkConfig.getString(StateBenchmarkOptions.STATE_DATA_DIR);
         benchmark =
                 new RescalingBenchmarkBuilder<byte[]>()
                         .setMaxParallelism(128)
                         .setParallelismBefore(rescaleType.getParallelismBefore())
                         .setParallelismAfter(rescaleType.getParallelismAfter())
                         .setCheckpointStorageAccess(
-                                new FileSystemCheckpointStorage(new URI("file://" + stateDataDirPath), 0)
+                                new FileSystemCheckpointStorage(new URI("file://" + prepareDirectory("rescaleDb").getAbsolutePath()), 0)
                                         .createCheckpointStorage(new JobID()))
                         .setStateBackend(stateBackend)
                         .setStreamRecordGenerator(new ByteArrayRecordGenerator(numberOfKeys, keyLen))

--- a/src/main/java/org/apache/flink/state/benchmark/RocksdbStateBackendRescalingBenchmarkExecutor.java
+++ b/src/main/java/org/apache/flink/state/benchmark/RocksdbStateBackendRescalingBenchmarkExecutor.java
@@ -48,8 +48,6 @@ public class RocksdbStateBackendRescalingBenchmarkExecutor extends RescalingBenc
     @Setup(Level.Trial)
     public void setUp() throws Exception {
         EmbeddedRocksDBStateBackend stateBackend = new EmbeddedRocksDBStateBackend(true);
-        Configuration benchMarkConfig = ConfigUtil.loadBenchMarkConf();
-        String stateDataDirPath = benchMarkConfig.getString(StateBenchmarkOptions.STATE_DATA_DIR);
         benchmark =
                 new RescalingBenchmarkBuilder<byte[]>()
                         .setMaxParallelism(128)
@@ -57,7 +55,7 @@ public class RocksdbStateBackendRescalingBenchmarkExecutor extends RescalingBenc
                         .setParallelismAfter(rescaleType.getParallelismAfter())
                         .setManagedMemorySize(512 * 1024 * 1024)
                         .setCheckpointStorageAccess(
-                                new FileSystemCheckpointStorage("file://" + stateDataDirPath)
+                                new FileSystemCheckpointStorage("file://" + prepareDirectory("rescaleDb").getAbsolutePath())
                                         .createCheckpointStorage(new JobID()))
                         .setStateBackend(stateBackend)
                         .setStreamRecordGenerator(new ByteArrayRecordGenerator(numberOfKeys, keyLen))


### PR DESCRIPTION
Currently, when setting up a rescaling benchmark, a local checkpoint storage is created based on a local path configured by "benchmark.state.data-dir". When user does not provide value for this option, an exception is thrown. In this case, the right behavior should be to create a temporary directory for checkpoint, just like the `StateBackendBenchmarkUtils#createKeyedStateBackend` does for local data directory.
