### PR TITLE
[FLINK-33161] Java17 profile for benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ There're mainly three ways:
     ```
     java -jar target/benchmarks.jar -rf csv "<benchmark_class>"
     ```
+   
+    When using uber jar with Java 17, you may need add arguments in command like:
+
+    ```
+    java --add-opens java.base/java.util=ALL-UNNAMED -jar target/benchmarks.jar -rf csv "<benchmark_class>"
+    ```
 
 We also support to run each benchmark once (with only one fork and one iteration) for testing, with below command:
 

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,93 @@ under the License.
 				</plugins>
 			</build>
 		</profile>
+
+		<profile>
+			<id>benchmark-java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+				<property>
+					<name>benchmarks</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>${maven.exec.version}</version>
+						<executions>
+							<execution>
+								<id>run-benchmarks</id>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<classpathScope>test</classpathScope>
+							<executable>${executableJava}</executable>
+							<arguments>
+								<argument>--add-opens</argument>
+								<argument>java.base/java.util=ALL-UNNAMED</argument>
+								<argument>-classpath</argument>
+								<classpath/>
+								<argument>org.openjdk.jmh.Main</argument>
+								<!--shouldFailOnError-->
+								<argument>-foe</argument>
+								<argument>true</argument>
+								<argument>-e</argument>
+								<argument>${benchmarkExcludes}</argument>
+								<argument>-rf</argument>
+								<argument>csv</argument>
+								<argument>${benchmarks}</argument>
+							</arguments>
+						</configuration>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<finalName>benchmarks</finalName>
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<mainClass>org.openjdk.jmh.Main</mainClass>
+										</transformer>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+											<resource>reference.conf</resource>
+										</transformer>
+										<!-- The service transformer is needed to merge META-INF/services files -->
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+											<projectName>Apache Flink</projectName>
+										</transformer>
+									</transformers>
+									<filters>
+										<filter>
+											<artifact>*</artifact>
+											<excludes>
+												<exclude>META-INF/*.SF</exclude>
+												<exclude>META-INF/*.DSA</exclude>
+												<exclude>META-INF/*.RSA</exclude>
+											</excludes>
+										</filter>
+									</filters>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 		<profile>
 			<id>custom-benchmark</id>
 			<activation>


### PR DESCRIPTION
Flink has supported java 17, however, the benchmark does not support running with java 17 out of the box. The runner complains:

```
Caused by: java.lang.RuntimeException: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.Object[] java.util.Arrays$ArrayList.a accessible: module java.base does not "opens java.util" to unnamed module @14899482
01:39:16 at com.twitter.chill.java.ArraysAsListSerializer.<init>(ArraysAsListSerializer.java:69)
01:39:16 at org.apache.flink.api.java.typeutils.runtime.kryo.FlinkChillPackageRegistrar.registerSerializers(FlinkChillPackageRegistrar.java:67)
01:39:16 at org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer.getKryoInstance(KryoSerializer.java:513)
01:39:16 at org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer.checkKryoInitialized(KryoSerializer.java:522)
01:39:16 at org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer.serialize(KryoSerializer.java:348)
01:39:16 at org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer.serialize(StreamElementSerializer.java:165)
01:39:16 at org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer.serialize(StreamElementSerializer.java:43)
01:39:16 at org.apache.flink.runtime.plugable.SerializationDelegate.write(SerializationDelegate.java:54)
01:39:16 at org.apache.flink.runtime.io.network.api.writer.RecordWriter.serializeRecord(RecordWriter.java:151)
01:39:16 at org.apache.flink.runtime.io.network.api.writer.RecordWriter.emit(RecordWriter.java:107)
01:39:16 at org.apache.flink.runtime.io.network.api.writer.ChannelSelectorRecordWriter.emit(ChannelSelectorRecordWriter.java:55)
01:39:16 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.pushToRecordWriter(RecordWriterOutput.java:134)
01:39:16 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.collectAndCheckIfChained(RecordWriterOutput.java:114)
01:39:16 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.collect(RecordWriterOutput.java:95)
01:39:16 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.collect(RecordWriterOutput.java:48)
01:39:16 at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:59)
01:39:16 at org.apache.flink.streaming.api.operators.CountingOutput.collect(CountingOutput.java:31)
01:39:16 at org.apache.flink.streaming.api.operators.StreamSourceContexts$ManualWatermarkContext.processAndCollect(StreamSourceContexts.java:425)
01:39:16 at org.apache.flink.streaming.api.operators.StreamSourceContexts$WatermarkContext.collect(StreamSourceContexts.java:520)
01:39:16 at org.apache.flink.streaming.api.operators.StreamSourceContexts$SwitchingOnClose.collect(StreamSourceContexts.java:110)
01:39:16 at org.apache.flink.benchmark.ContinuousFileReaderOperatorBenchmark$MockSourceFunction.run(ContinuousFileReaderOperatorBenchmark.java:101)
01:39:16 at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:114)
01:39:16 at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:71)
01:39:16 at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.run(SourceStreamTask.java:338)
01:39:16 Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.Object[] java.util.Arrays$ArrayList.a accessible: module java.base does not "opens java.util" to unnamed module @14899482
01:39:16 at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
01:39:16 at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
01:39:16 at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
01:39:16 at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
01:39:16 at com.twitter.chill.java.ArraysAsListSerializer.<init>(ArraysAsListSerializer.java:67)
01:39:16 ... 23 more
```
 
To resolve this, we should add a target profile for java 17 in pom.xml of benchmark project and provide some cli arg like "--add-opens java.base/java.util=ALL-UNNAMED" for the execution.

This fixes https://issues.apache.org/jira/browse/FLINK-33161
