### PR TITLE
[FLINK-33482] Flink benchmark regression check in new machines hosted on Aliyun

### DIFF
--- a/jenkinsfiles/regression-check.jenkinsfile
+++ b/jenkinsfiles/regression-check.jenkinsfile
@@ -18,10 +18,10 @@
 timestamps {
     try {
         timeout(time: 3, unit: 'HOURS') { // includes waiting for a machine
-            node('Hetzner') {
+            node('Aliyun') {
                 dir('flink-benchmarks') {
                     git url: 'https://github.com/apache/flink-benchmarks.git', branch: 'master'
-                    sh './regression_report_v2.py > regression-report'
+                    sh 'python2 ./regression_report_v2.py > regression-report'
                     def alerts = readFile "regression-report"
                     if (alerts) {
                          def attachments = [


### PR DESCRIPTION
After [FLINK-33052](https://issues.apache.org/jira/browse/FLINK-33052), the codespeed and benchmark servers are hosted on Aliyun. This PR modifies the benchmark daily monitoring scripts for the new environment.