### PR TITLE
[hotfix] Extract common preparing directory code into one function

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/RescalingBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/state/benchmark/RescalingBenchmarkBase.java
@@ -46,6 +46,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Random;
 
+import static org.apache.flink.state.benchmark.StateBenchmarkBase.createStateDataDir;
+
 public class RescalingBenchmarkBase extends BenchmarkBase {
 
     @Param({"RESCALE_IN", "RESCALE_OUT"})
@@ -64,23 +66,7 @@ public class RescalingBenchmarkBase extends BenchmarkBase {
     }
 
     protected static File prepareDirectory(String prefix) throws IOException {
-        Configuration benchMarkConfig = ConfigUtil.loadBenchMarkConf();
-        String stateDataDirPath = benchMarkConfig.getString(StateBenchmarkOptions.STATE_DATA_DIR);
-        File dataDir = null;
-        if (stateDataDirPath != null) {
-            dataDir = new File(stateDataDirPath);
-            if (!dataDir.exists()) {
-                Files.createDirectories(Paths.get(stateDataDirPath));
-            }
-        }
-        File target = File.createTempFile(prefix, "", dataDir);
-        if (target.exists() && !target.delete()) {
-            throw new IOException("Target dir {" + target.getAbsolutePath() + "} exists but failed to clean it up");
-        } else if (!target.mkdirs()) {
-            throw new IOException("Failed to create target directory: " + target.getAbsolutePath());
-        } else {
-            return target;
-        }
+        return StateBackendBenchmarkUtils.prepareDirectory(prefix, createStateDataDir());
     }
 
     @State(Scope.Thread)

--- a/src/main/java/org/apache/flink/state/benchmark/StateBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/state/benchmark/StateBenchmarkBase.java
@@ -67,6 +67,10 @@ public class StateBenchmarkBase extends BenchmarkBase {
     }
 
     protected KeyedStateBackend<Long> createKeyedStateBackend(TtlTimeProvider ttlTimeProvider) throws Exception {
+        return StateBackendBenchmarkUtils.createKeyedStateBackend(backendType, createStateDataDir());
+    }
+
+    public static File createStateDataDir() throws IOException {
         Configuration benchMarkConfig = ConfigUtil.loadBenchMarkConf();
         String stateDataDirPath = benchMarkConfig.getString(StateBenchmarkOptions.STATE_DATA_DIR);
         File dataDir = null;
@@ -76,7 +80,7 @@ public class StateBenchmarkBase extends BenchmarkBase {
                 Files.createDirectories(Paths.get(stateDataDirPath));
             }
         }
-        return StateBackendBenchmarkUtils.createKeyedStateBackend(backendType, dataDir);
+        return dataDir;
     }
 
     private static int getCurrentIndex() {


### PR DESCRIPTION
In https://github.com/apache/flink-benchmarks/pull/79#discussion_r1333857024, we left some duplicated code in preparing the directory for state benchmark. This PR do some code extraction to fix this.