### PR TITLE
[FLINK-34164] Fix compilation issue

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/StreamGraphUtils.java
+++ b/src/main/java/org/apache/flink/benchmark/StreamGraphUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.benchmark;
 
 import org.apache.flink.benchmark.functions.LongSource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -34,8 +36,11 @@ public class StreamGraphUtils {
         DataStreamSource<Long> source = env.addSource(new LongSource(numRecords));
         source.addSink(new DiscardingSink<>());
 
+        Configuration config = new Configuration();
+        config.set(PipelineOptions.OPERATOR_CHAINING, false);
+        env.configure(config);
+
         StreamGraph streamGraph = env.getStreamGraph();
-        streamGraph.setChaining(false);
         streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
         streamGraph.setJobType(JobType.BATCH);
 


### PR DESCRIPTION
Since FLINK-33980 changed the interface of StreamGraph,  it is necessary to align the flink-benchmark project with these updates.