### PR TITLE
[FLINK-34453] Add warmup in SchedulerBenchmarkExecutorBase

### DIFF
--- a/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkExecutorBase.java
+++ b/src/main/java/org/apache/flink/scheduler/benchmark/SchedulerBenchmarkExecutorBase.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 20)
 @Fork(
         value = 6,
         jvmArgsAppend = {


### PR DESCRIPTION
This will stabilize the perf score of benchmarks for runtime scheduler.