### PR TITLE
[hotfix] Fix compilation error due to constructor removal of MockSourceReader

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/MultipleInputBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MultipleInputBenchmark.java
@@ -167,7 +167,7 @@ public class MultipleInputBenchmark extends BenchmarkBase {
         @Override
         public SourceReader<Integer, MockSourceSplit> createReader(
                 SourceReaderContext readerContext) {
-            return new MockSourceReader(true, true) {
+            return new MockSourceReader(MockSourceReader.WaitingForSplits.WAIT_UNTIL_ALL_SPLITS_ASSIGNED, true) {
                 @Override
                 public InputStatus pollNext(ReaderOutput<Integer> sourceOutput) {
                     if (canFinish.isDone() && !canFinish.isCompletedExceptionally()) {


### PR DESCRIPTION
Due to this commit in main repo https://github.com/apache/flink/commit/41391065e1bf1476040039077049fbb98bec457e , there is a compilation error. This PR change to use another constructor of `MockSourceReader` to fix this.