### PR TITLE
[FLINK-35682] Bump Flink version to 2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.20-SNAPSHOT</flink.version>
+		<flink.version>2.0-SNAPSHOT</flink.version>
 		<flink.shaded.version>16.1</flink.shaded.version>
 		<netty.tcnative.version>2.0.54.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>


### PR DESCRIPTION
Update this as flink master branch has been updated to `2.0-SNAPSHOT`.