### PR TITLE
Use chronological order timestamp for timers

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java
@@ -112,7 +112,7 @@ public class ProcessingTimerBenchmark extends BenchmarkBase {
                 throws Exception {
             final long currTimestamp = System.currentTimeMillis();
             for (int i = 0; i < timersPerRecord; i++) {
-                context.timerService().registerProcessingTimeTimer(currTimestamp - i - 1);
+                context.timerService().registerProcessingTimeTimer(currTimestamp - timersPerRecord + i);
             }
         }
 


### PR DESCRIPTION
https://github.com/apache/flink-benchmarks/pull/25#issuecomment-2340079177