### PR TITLE
[hotfix] Use `Duration` instead of `Time`

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
@@ -20,7 +20,6 @@ package org.apache.flink.benchmark;
 
 import org.apache.flink.benchmark.functions.IntLongApplications;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
@@ -31,6 +30,8 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.time.Duration;
 
 import static org.openjdk.jmh.annotations.Scope.Thread;
 
@@ -51,7 +52,7 @@ public class MemoryStateBackendBenchmark extends StateBackendBenchmarkBase {
     @Benchmark
     public void stateBackends(MemoryStateBackendContext context) throws Exception {
         IntLongApplications.reduceWithWindow(
-                context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+                context.source, TumblingEventTimeWindows.of(Duration.ofSeconds(10_000)));
         context.execute();
     }
 

--- a/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.contrib.streaming.state.RocksDBOptions;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
@@ -34,6 +33,8 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.time.Duration;
 
 import static org.openjdk.jmh.annotations.Scope.Thread;
 
@@ -54,7 +55,7 @@ public class RocksStateBackendBenchmark extends StateBackendBenchmarkBase {
     @Benchmark
     public void stateBackends(RocksStateBackendContext context) throws Exception {
         IntLongApplications.reduceWithWindow(
-                context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+                context.source, TumblingEventTimeWindows.of(Duration.ofSeconds(10_000)));
         context.execute();
     }
 

--- a/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
@@ -26,7 +26,6 @@ import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindow
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
@@ -35,6 +34,8 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.time.Duration;
 
 @OperationsPerInvocation(value = WindowBenchmarks.RECORDS_PER_INVOCATION)
 public class WindowBenchmarks extends BenchmarkBase {
@@ -60,7 +61,7 @@ public class WindowBenchmarks extends BenchmarkBase {
     @Benchmark
     public void tumblingWindow(TimeWindowContext context) throws Exception {
         IntLongApplications.reduceWithWindow(
-                context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+                context.source, TumblingEventTimeWindows.of(Duration.ofSeconds(10_000)));
         context.execute();
     }
 
@@ -68,14 +69,14 @@ public class WindowBenchmarks extends BenchmarkBase {
     public void slidingWindow(TimeWindowContext context) throws Exception {
         IntLongApplications.reduceWithWindow(
                 context.source,
-                SlidingEventTimeWindows.of(Time.seconds(10_000), Time.seconds(1000)));
+                SlidingEventTimeWindows.of(Duration.ofSeconds(10_000), Duration.ofSeconds(1000)));
         context.execute();
     }
 
     @Benchmark
     public void sessionWindow(TimeWindowContext context) throws Exception {
         IntLongApplications.reduceWithWindow(
-                context.source, EventTimeSessionWindows.withGap(Time.seconds(500)));
+                context.source, EventTimeSessionWindows.withGap(Duration.ofSeconds(500)));
         context.execute();
     }
 

--- a/src/main/java/org/apache/flink/state/benchmark/ttl/TtlStateBenchmarkBase.java
+++ b/src/main/java/org/apache/flink/state/benchmark/ttl/TtlStateBenchmarkBase.java
@@ -20,13 +20,12 @@ package org.apache.flink.state.benchmark.ttl;
 
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.benchmark.StateBenchmarkBase;
 import org.openjdk.jmh.annotations.Param;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 /** The base class for state tests with ttl. */
 public class TtlStateBenchmarkBase extends StateBenchmarkBase {
@@ -62,7 +61,7 @@ public class TtlStateBenchmarkBase extends StateBenchmarkBase {
     /** Configure the state descriptor with ttl. */
     protected <T extends StateDescriptor<?, ?>> T configTtl(T stateDescriptor) {
         StateTtlConfig ttlConfig =
-                new StateTtlConfig.Builder(Time.of(initialTime, TimeUnit.MILLISECONDS))
+                StateTtlConfig.newBuilder(Duration.ofMillis(initialTime))
                         .setUpdateType(updateType)
                         .setStateVisibility(stateVisibility)
                         .build();


### PR DESCRIPTION
Due to https://github.com/apache/flink/pull/25250 , the TTL builder using `org.apache.flink.api.common.time.Time` is removed. This PR fixes this.