### PR TITLE
[FLINK-37035][release] Bump Flink version to 2.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>2.0-SNAPSHOT</flink.version>
+		<flink.version>2.1-SNAPSHOT</flink.version>
 		<flink.shaded.version>19.0</flink.shaded.version>
 		<netty.tcnative.version>2.0.62.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>


### PR DESCRIPTION
For apache/flink 2.0.0 release.