### PR TITLE
[FLINK-37376] Upgrade flink-shaded to 20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>2.1-SNAPSHOT</flink.version>
-		<flink.shaded.version>19.0</flink.shaded.version>
+		<flink.shaded.version>20.0</flink.shaded.version>
 		<netty.tcnative.version>2.0.62.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
Upgrading flink-shaded as the last step of flink-shaded release mentioned at
https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=85472039#Creatingaflinkshadedrelease-Deploysourceandbinaryreleasestodist.apache.org