### PR TITLE
[FLINK-39787][build] Map runner hostname to loopback to avoid SSL SAN mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       # FLINK-39787: GitHub-hosted Azure runners assign a VM hostname whose
       # reverse DNS returns an internal cloudapp.net FQDN. The SSL benchmarks
@@ -42,14 +42,14 @@ jobs:
           getent hosts 127.0.0.1
 
       - name: Set JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Set Maven 3.8.6
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # FLINK-39787: GitHub-hosted Azure runners assign a VM hostname whose
+      # reverse DNS returns an internal cloudapp.net FQDN. The SSL benchmarks
+      # rely on flink-runtime's local127.keystore, whose SAN list only contains
+      # 'localhost', '127.0.0.1', and '::1'. Map the runner hostname to the
+      # loopback interface so InetAddress.getLocalHost() (used to bind the
+      # benchmark NettyServer) returns 127.0.0.1 and the SSL handshake matches
+      # the certificate. The real fix belongs in apache/flink's
+      # StreamNetworkBenchmarkEnvironment (use getLoopbackAddress instead of
+      # getLocalHost); track separately.
+      - name: Map runner hostname to loopback
+        run: |
+          sudo sed -i "/$(hostname)/d" /etc/hosts
+          echo "127.0.0.1 localhost $(hostname -f) $(hostname)" | sudo tee -a /etc/hosts
+          echo "After shim:"
+          getent hosts "$(hostname)"
+          getent hosts 127.0.0.1
+
       - name: Set JDK
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
GitHub-hosted Azure runners assign a VM hostname whose reverse DNS returns an internal cloudapp.net FQDN. flink-runtime's SSL test certificate (local127.keystore) lists only 'localhost', '127.0.0.1', and '::1' as SANs, so the SSL handshake in
StreamNetworkThroughputBenchmark fails and the benchmark hangs until GitHub kills the job at the 6h timeout.

Prepend a loopback mapping for the runner hostname to /etc/hosts so InetAddress.getLocalHost() (used by StreamNetworkBenchmarkEnvironment to bind the NettyServer) returns 127.0.0.1; reverse DNS on that IP then yields 'localhost', which matches the certificate.